### PR TITLE
Update KCL function and tests to be more idiomatic

### DIFF
--- a/template/functions/compose-bucket-kcl/main.k
+++ b/template/functions/compose-bucket-kcl/main.k
@@ -1,15 +1,10 @@
 import models.io.upbound.aws.s3.v1beta1 as s3v1beta1
 import models.com.example.platform.v1alpha1.xstoragebucket as xstoragebucketv1alpha1
 
-oxr = option("params").oxr
-# https://github.com/upbound/up/pull/432
-# oxr = xstoragebucketv1alpha1.XStorageBucket{**option("params").oxr}
-
-bucketName = "{}-bucket".format(oxr.metadata.name)
+oxr = xstoragebucketv1alpha1.XStorageBucket{**option("params").oxr}
 
 _metadata = lambda name: str -> any {
   {
-    name = name
     annotations = {
       "krm.kcl.dev/composition-resource-name" = name
     }
@@ -19,98 +14,104 @@ _metadata = lambda name: str -> any {
 _items: [any] = [
     # Bucket in the desired region
     s3v1beta1.Bucket{
-        metadata: _metadata(bucketName)
+        metadata: _metadata("bucket")
         spec = {
             forProvider = {
                 region = oxr.spec.parameters.region
-            }
-        }
-    },
-    s3v1beta1.BucketOwnershipControls{
-        metadata: _metadata("{}-boc".format(oxr.metadata.name))
-        spec = {
-            forProvider = {
-                bucketRef = {
-                    name = bucketName
-                }
-                region = oxr.spec.parameters.region
-                rule:[{
-                    objectOwnership:"BucketOwnerPreferred"
-                }]
-            }
-        }
-    },
-    s3v1beta1.BucketPublicAccessBlock{
-        metadata: _metadata("{}-pab".format(oxr.metadata.name))
-        spec = {
-            forProvider = {
-                bucketRef = {
-                    name = bucketName
-                }
-                region = oxr.spec.parameters.region
-                blockPublicAcls: False
-                ignorePublicAcls: False
-                restrictPublicBuckets: False
-                blockPublicPolicy: False
-            }
-        }
-    },
-    # ACL for the bucket
-    s3v1beta1.BucketACL{
-        metadata: _metadata("{}-acl".format(oxr.metadata.name))
-        spec = {
-            forProvider = {
-                bucketRef = {
-                    name = bucketName
-                }
-                region = oxr.spec.parameters.region
-                acl = oxr.spec.parameters.acl
-            }
-        }
-    },
-    # Default encryption for the bucket
-    s3v1beta1.BucketServerSideEncryptionConfiguration{
-        metadata: _metadata("{}-encryption".format(oxr.metadata.name))
-        spec = {
-            forProvider = {
-                region = oxr.spec.parameters.region
-                bucketRef = {
-                    name = bucketName
-                }
-                rule = [
-                    {
-                        applyServerSideEncryptionByDefault = [
-                            {
-                                sseAlgorithm = "AES256"
-                            }
-                        ]
-                        bucketKeyEnabled = True
-                    }
-                ]
             }
         }
     }
 ]
 
-# Set up versioning for the bucket if desired
-if oxr.spec.parameters.versioning:
+ocds = option("params").ocds
+bucketName = ocds["bucket"]?.Resource?.metadata?.name
+if bucketName:
     _items += [
-        s3v1beta1.BucketVersioning{
-            metadata: _metadata("{}-versioning".format(oxr.metadata.name))
+        s3v1beta1.BucketOwnershipControls{
+            metadata: _metadata("boc")
+            spec = {
+                forProvider = {
+                    bucketRef = {
+                        name = bucketName
+                    }
+                    region = oxr.spec.parameters.region
+                    rule:[{
+                        objectOwnership:"BucketOwnerPreferred"
+                    }]
+                }
+            }
+        },
+        s3v1beta1.BucketPublicAccessBlock{
+            metadata: _metadata("pab")
+            spec = {
+                forProvider = {
+                    bucketRef = {
+                        name = bucketName
+                    }
+                    region = oxr.spec.parameters.region
+                    blockPublicAcls: False
+                    ignorePublicAcls: False
+                    restrictPublicBuckets: False
+                    blockPublicPolicy: False
+                }
+            }
+        },
+        # ACL for the bucket
+        s3v1beta1.BucketACL{
+            metadata: _metadata("acl")
+            spec = {
+                forProvider = {
+                    bucketRef = {
+                        name = bucketName
+                    }
+                    region = oxr.spec.parameters.region
+                    acl = oxr.spec.parameters.acl
+                }
+            }
+        },
+        # Default encryption for the bucket
+        s3v1beta1.BucketServerSideEncryptionConfiguration{
+            metadata: _metadata("encryption")
             spec = {
                 forProvider = {
                     region = oxr.spec.parameters.region
                     bucketRef = {
                         name = bucketName
                     }
-                    versioningConfiguration = [
+                    rule = [
                         {
-                            status = "Enabled"
+                            applyServerSideEncryptionByDefault = [
+                                {
+                                    sseAlgorithm = "AES256"
+                                }
+                            ]
+                            bucketKeyEnabled = True
                         }
                     ]
                 }
             }
         }
     ]
+
+    # Set up versioning for the bucket if desired
+    if oxr.spec.parameters.versioning:
+        _items += [
+            s3v1beta1.BucketVersioning{
+                metadata: _metadata("versioning")
+                spec = {
+                    forProvider = {
+                        region = oxr.spec.parameters.region
+                        bucketRef = {
+                            name = bucketName
+                        }
+                        versioningConfiguration = [
+                            {
+                                status = "Enabled"
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
 
 items = _items

--- a/template/tests/test-xstoragebucket-kcl/main.k
+++ b/template/tests/test-xstoragebucket-kcl/main.k
@@ -1,105 +1,59 @@
-import models.com.example.platform.v1alpha1 as platformv1alpha1
-import models.io.upbound.aws.s3.v1beta1 as s3v1beta1
-import models.io.upbound.dev.meta.v1alpha1 as metav1alpha1
+"""
 
-_items = [
-    metav1alpha1.CompositionTest{
-        metadata.name="test-xstoragebucket"
-        spec= {
-            assertResources: [
-                platformv1alpha1.XStorageBucket{
-                    metadata.name: "example"
-                    spec: {
-                        parameters: {
-                            acl: "public-read"
-                            region: "us-west-1"
-                            versioning: True
-                        }
-                    }
-                }
-                s3v1beta1.BucketACL{
-                    metadata.name: "example-acl"
-                    spec.forProvider:{
-                        acl: "public-read"
-                        bucketRef: {
-                            name: "example-bucket"
-                        }
-                        region: "us-west-1"
-                    }
-                }
-                s3v1beta1.BucketOwnershipControls{
-                    metadata.name: "example-boc"
-                    spec.forProvider: {
-                        bucketRef: {
-                            name: "example-bucket"
-                        }
-                        region: "us-west-1"
-                        rule: [
-                            {
-                                objectOwnership: "BucketOwnerPreferred"
-                            }
-                        ]
-                    }
-                }
-                s3v1beta1.Bucket{
-                    metadata.name: "example-bucket"
-                    spec.forProvider: {
-                        region: "us-west-1"
-                    }
-                }
-                s3v1beta1.BucketServerSideEncryptionConfiguration{
-                    metadata.name: "example-encryption"
-                    spec.forProvider: {
-                        bucketRef: {
-                            name: "example-bucket"
-                        }
-                        region: "us-west-1"
-                        rule: [
-                            {
-                                applyServerSideEncryptionByDefault: [
-                                    {
-                                        sseAlgorithm: "AES256"
-                                    }
-                                ]
-                                bucketKeyEnabled: True
-                            }
-                        ]
-                    }
-                }
-                s3v1beta1.BucketPublicAccessBlock{
-                    metadata.name: "example-pab"
-                    spec.forProvider: {
-                        blockPublicAcls: False
-                        blockPublicPolicy: False
-                        bucketRef: {
-                            name: "example-bucket"
-                        }
-                        ignorePublicAcls: False
-                        region: "us-west-1"
-                        restrictPublicBuckets: False
-                    }
-                }
-                s3v1beta1.BucketVersioning{
-                    metadata.name: "example-versioning"
-                    spec.forProvider: {
-                        bucketRef: {
-                            name: "example-bucket"
-                        }
-                        region: "us-west-1"
-                        versioningConfiguration: [
-                            {
-                                status: "Enabled"
-                            },
-                        ]
-                    }
-                }
-            ]
-            compositionPath: "apis/xstoragebucket/composition.yaml"
-            xrPath: "examples/xstoragebuckets/example.yaml"
-            xrdPath: "apis/xstoragebucket/definition.yaml"
-            timeoutSeconds: 120
-            validate: False
-        }
+This test suite validates the creation of resources for the XStorageBucket XR.
+
+Creation of resources happens in two sequential calls to the composition
+function:
+
+1. The first time the function is called, the bucket has not yet been
+   created. Other resources depend on the bucket's name, so the function creates
+   only the bucket.
+
+2. When the function is called again after the bucket has been created, its name
+   is available, so the rest of the resources can be created.
+
+The test suite contains two tests, one for each of the sequential calls. The
+second test includes the bucket in its observed resources, triggering creation
+of the dependent resources.
+"""
+
+import models.io.upbound.dev.meta.v1alpha1 as metav1alpha1
+import resources
+
+_spec = metav1alpha1.CompositionTest {
+    spec = {
+        compositionPath: "apis/xstoragebucket/composition.yaml"
+        xrPath: "examples/xstoragebuckets/example.yaml"
+        xrdPath: "apis/xstoragebucket/definition.yaml"
+        timeoutSeconds: 120
+        validate: False
     }
-]
-items = _items
+}
+
+_test1 = metav1alpha1.CompositionTest {
+    metadata.name = "test-xstoragebucket-bucket-not-yet-created"
+    **_spec
+    spec.assertResources = [
+        resources._expectedXR
+        resources._expectedBucket
+    ]
+}
+
+_test2 = metav1alpha1.CompositionTest {
+    metadata.name = "tests-xstoragebucket-bucket-created"
+    **_spec
+    spec.observedResources = [
+        resources._observedBucket
+    ]
+    spec.assertResources = [
+        resources._expectedXR
+        resources._observedBucket
+        resources._expectedACL
+        resources._expectedBOC
+        resources._expectedPAB
+        resources._expectedEncryption
+        resources._expectedVersioning
+    ]
+}
+
+items = [_test1, _test2]

--- a/template/tests/test-xstoragebucket-kcl/resources.k
+++ b/template/tests/test-xstoragebucket-kcl/resources.k
@@ -1,0 +1,117 @@
+import models.com.example.platform.v1alpha1 as platformv1alpha1
+import models.io.upbound.aws.s3.v1beta1 as s3v1beta1
+
+_expectedXR =  platformv1alpha1.XStorageBucket{
+    metadata.name: "example"
+    spec: {
+        parameters: {
+            acl: "public-read"
+            region: "us-west-1"
+            versioning: True
+        }
+    }
+}
+
+_expectedBucket = s3v1beta1.Bucket{
+    metadata.annotations: {
+        "crossplane.io/composition-resource-name": "bucket"
+    }
+    spec.forProvider: {
+        region: "us-west-1"
+    }
+}
+
+_observedBucket = s3v1beta1.Bucket{
+    metadata.name: "example-bucket"
+    metadata.annotations: {
+        "crossplane.io/composition-resource-name": "bucket"
+    }
+    spec.forProvider: {
+        region: "us-west-1"
+    }
+}
+
+_expectedACL = s3v1beta1.BucketACL{
+    metadata.annotations: {
+        "crossplane.io/composition-resource-name": "acl"
+    }
+    spec.forProvider:{
+        acl: "public-read"
+        bucketRef: {
+            name: "example-bucket"
+        }
+        region: "us-west-1"
+    }
+}
+
+_expectedBOC = s3v1beta1.BucketOwnershipControls{
+    metadata.annotations: {
+        "crossplane.io/composition-resource-name": "boc"
+    }
+    spec.forProvider: {
+        bucketRef: {
+            name: "example-bucket"
+        }
+        region: "us-west-1"
+        rule: [
+            {
+                objectOwnership: "BucketOwnerPreferred"
+            }
+        ]
+    }
+}
+
+_expectedEncryption = s3v1beta1.BucketServerSideEncryptionConfiguration{
+    metadata.annotations: {
+        "crossplane.io/composition-resource-name": "encryption"
+    }
+    spec.forProvider: {
+        bucketRef: {
+            name: "example-bucket"
+        }
+        region: "us-west-1"
+        rule: [
+            {
+                applyServerSideEncryptionByDefault: [
+                    {
+                        sseAlgorithm: "AES256"
+                    }
+                ]
+                bucketKeyEnabled: True
+            }
+        ]
+    }
+}
+
+_expectedPAB = s3v1beta1.BucketPublicAccessBlock{
+    metadata.annotations: {
+        "crossplane.io/composition-resource-name": "pab"
+    }
+    spec.forProvider: {
+        blockPublicAcls: False
+        blockPublicPolicy: False
+        bucketRef: {
+            name: "example-bucket"
+        }
+        ignorePublicAcls: False
+        region: "us-west-1"
+        restrictPublicBuckets: False
+    }
+}
+
+_expectedVersioning = s3v1beta1.BucketVersioning{
+    metadata.annotations: {
+        "crossplane.io/composition-resource-name": "versioning"
+    }
+    spec.forProvider: {
+        bucketRef: {
+            name: "example-bucket"
+        }
+        region: "us-west-1"
+        versioningConfiguration: [
+            {
+                status: "Enabled"
+            },
+        ]
+    }
+}


### PR DESCRIPTION
### Description of your changes

Stop setting the `metadata.name` of resources in the KCL function so that we let Crossplane generate a name that will avoid conflicts. To accommodate this in the tests, split the composition test in two. The first test is for the case where the bucket has not yet been named; the second for the test where it has. We now match desired resources by the `composition-resource-name` annotation since we don't name them.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
~- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.~

### How has this code been tested

`up test run` with an updated up binary.
