### PR TITLE
Update e2es to use local runner with injected AWS credentials

### DIFF
--- a/.github/supportbundle.yaml
+++ b/.github/supportbundle.yaml
@@ -1,0 +1,7 @@
+apiVersion: troubleshoot.sh/v1beta2
+kind: SupportBundle
+metadata:
+  name: supportbundle
+spec:
+  collectors: []
+  analyzers: []

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -66,4 +66,40 @@ jobs:
           UP_AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
           UP_AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
           UP_AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
-        run: cd generated-project && up test run tests/* --e2e --local
+        run: cd generated-project && up test run tests/* --e2e --local --skip-control-plane-cleanup
+
+      - name: Install kind CLI
+        if: failure()
+        run: |
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.20.0/kind-linux-amd64
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+
+      - name: Install supportbundle CLI
+        if: failure()
+        run: |
+          curl -Lo ./support-bundle https://github.com/replicatedhq/troubleshoot/releases/latest/download/support-bundle_linux_amd64.tar.gz
+          tar -xzf ./support-bundle
+          chmod +x ./support-bundle
+          sudo mv ./support-bundle /usr/local/bin/support-bundle
+
+      - name: Collect diagnostic information
+        if: failure()
+        run: |
+          kind get clusters
+          FIRST_CLUSTER=$(kind get clusters | head -n 1)
+          if [ -n "$FIRST_CLUSTER" ]; then
+            kind export kubeconfig --name "$FIRST_CLUSTER"
+            support-bundle --kubeconfig ~/.kube/config --output support-bundle.tar.gz ./template/.github/supportbundle.yaml
+          else
+            echo "No kind clusters found"
+            touch support-bundle.tar.gz
+          fi
+
+      - name: Upload support bundle
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: support-bundle-${{ matrix.language }}-${{ matrix.test-language }}
+          path: support-bundle.tar.gz
+          retention-days: 1

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -8,6 +8,7 @@ on:
     types:
       - synchronize
       - labeled
+  workflow_dispatch:
 
 env:
   UP_API_TOKEN: ${{ secrets.UP_API_TOKEN }}
@@ -15,7 +16,7 @@ env:
 
 jobs:
   e2e:
-    if: contains(github.event.pull_request.labels.*.name, 'run-e2e-tests')
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-e2e-tests')
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -10,8 +10,11 @@ on:
       - labeled
   workflow_dispatch:
 
+permissions:
+  id-token: write   # Required for OIDC authentication
+  contents: read    # Required for checkout
+
 env:
-  UP_API_TOKEN: ${{ secrets.UP_API_TOKEN }}
   UP_ORG: ${{ secrets.UP_ORG }}
   AWS_REGION: us-east-1
 
@@ -21,10 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # language: [go, go-templating, kcl, python]
-        # test-language: [kcl, python]
-        language: [go]
-        test-language: [python]
+        language: [go, go-templating, kcl, python]
+        test-language: [kcl, python]
     steps:
       - name: Checkout
         id: checkout
@@ -52,6 +53,7 @@ jobs:
           api-token: ${{ secrets.UP_API_TOKEN }}
           organization: ${{ secrets.UP_ORG }}
           channel: main
+          version: v0.39.0-121.g5a95e138
 
       - name: Initialize project
         run: up project init -e ./template generated-project --language ${{ matrix.language }} --test-language ${{ matrix.test-language }}
@@ -59,10 +61,9 @@ jobs:
       - name: Build project
         run: cd generated-project && up project build
 
-      - name: Switch up context
-        if: env.UP_API_TOKEN != '' && env.UP_ORG != ''
-        run: up ctx ${{ secrets.UP_ORG }}/upbound-gcp-us-central-1/default
-
       - name: Run e2e tests
-        if: env.UP_API_TOKEN != '' && env.UP_ORG != ''
-        run: cd generated-project && UP_AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID UP_AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY UP_AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN up test run tests/* --e2e --local
+        env:
+          UP_AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
+          UP_AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          UP_AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
+        run: cd generated-project && up test run tests/* --e2e --local

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -56,4 +56,4 @@ jobs:
 
       - name: Run e2e tests
         if: env.UP_API_TOKEN != '' && env.UP_ORG != ''
-        run: cd generated-project && up test run tests/* --e2e
+        run: cd generated-project && up test run tests/* --e2e --control-plane-name-prefix ${{ matrix.language }}-${{ matrix.test-language }}-

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -13,6 +13,7 @@ on:
 env:
   UP_API_TOKEN: ${{ secrets.UP_API_TOKEN }}
   UP_ORG: ${{ secrets.UP_ORG }}
+  AWS_REGION: us-east-1
 
 jobs:
   e2e:
@@ -20,14 +21,22 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        language: [go, go-templating, kcl, python]
-        test-language: [kcl, python]
+        # language: [go, go-templating, kcl, python]
+        # test-language: [kcl, python]
+        language: [go]
+        test-language: [python]
     steps:
       - name: Checkout
         id: checkout
         uses: actions/checkout@v4
         with:
           path: ./template
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Setup Go
         id: setup-go
@@ -56,4 +65,4 @@ jobs:
 
       - name: Run e2e tests
         if: env.UP_API_TOKEN != '' && env.UP_ORG != ''
-        run: cd generated-project && up test run tests/* --e2e --control-plane-name-prefix ${{ matrix.language }}-${{ matrix.test-language }}-
+        run: cd generated-project && UP_AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID UP_AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY UP_AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN up test run tests/* --e2e --local

--- a/template/tests/e2etest-xstoragebucket-kcl/main.k
+++ b/template/tests/e2etest-xstoragebucket-kcl/main.k
@@ -26,7 +26,7 @@ _items = [
                     spec.credentials = {
                         source = "Upbound"
                         upbound.webIdentity = {
-                            roleARN = "arn:aws:iam::609897127049:role/example-project-aws-uptest"
+                            roleARN = "arn:aws:iam::609897127049:role/project-example-aws-uptest"
                         }
                     }
                 }

--- a/template/tests/e2etest-xstoragebucket-kcl/main.k
+++ b/template/tests/e2etest-xstoragebucket-kcl/main.k
@@ -1,6 +1,22 @@
+import base64
+import file
+
 import models.com.example.platform.v1alpha1 as platformv1alpha1
 import models.io.upbound.aws.v1beta1 as awsv1beta1
 import models.io.upbound.dev.meta.v1alpha1 as metav1alpha1
+import models.k8s.apimachinery.pkg.apis.meta.v1 as k8s
+
+aws_access_key_id = file.read_env("UP_AWS_ACCESS_KEY_ID")
+aws_secret_access_key = file.read_env("UP_AWS_SECRET_ACCESS_KEY")
+aws_session_token = file.read_env("UP_AWS_SESSION_TOKEN")
+
+
+schema Secret:
+    apiVersion: "v1" = "v1"
+    kind: "Secret" = "Secret"
+    metadata?: k8s.ObjectMeta
+    type: "Opaque" = "Opaque"
+    data?: {str:str}
 
 _items = [
     metav1alpha1.E2ETest{
@@ -24,10 +40,25 @@ _items = [
                 awsv1beta1.ProviderConfig{
                     metadata.name = "default"
                     spec.credentials = {
-                        source = "Upbound"
-                        upbound.webIdentity = {
-                            roleARN = "arn:aws:iam::609897127049:role/project-example-aws-uptest"
+                        source = "Secret"
+                        secretRef = {
+                            name = "aws-credentials"
+                            namespace = "crossplane-system"
+                            key = "credentials"
                         }
+                    }
+                },
+                Secret{
+                    metadata={
+                        name="aws-credentials",
+                        namespace="crossplane-system",
+                    },
+                    data={
+                        "credentials": base64.encode("""[default]
+aws_access_key_id = ${aws_access_key_id}
+aws_secret_access_key = ${aws_secret_access_key}
+aws_session_token = ${aws_session_token}
+""")
                     }
                 }
             ]

--- a/template/tests/e2etest-xstoragebucket-kcl/main.k
+++ b/template/tests/e2etest-xstoragebucket-kcl/main.k
@@ -63,7 +63,7 @@ aws_session_token = ${aws_session_token}
                 }
             ]
             skipDelete = False
-            timeoutSeconds = 900 # 15 minutes
+            timeoutSeconds = 300 # 5 minutes
         }
     }
 ]

--- a/template/tests/e2etest-xstoragebucket-python/main.py
+++ b/template/tests/e2etest-xstoragebucket-python/main.py
@@ -73,6 +73,6 @@ test = e2etest.E2ETest(
         manifests=[bucket_manifest.model_dump()],
         extraResources=[provider_config.model_dump(), provider_creds.model_dump()],
         skipDelete=False,
-        timeoutSeconds=900, # 15 minutes
+        timeoutSeconds=300, # 5 minutes
     )
 )

--- a/template/tests/e2etest-xstoragebucket-python/main.py
+++ b/template/tests/e2etest-xstoragebucket-python/main.py
@@ -1,7 +1,18 @@
+import base64
+import os
+from pydantic import BaseModel
+
 from .model.io.upbound.dev.meta.e2etest import v1alpha1 as e2etest
 from .model.io.k8s.apimachinery.pkg.apis.meta import v1 as k8s
 from .model.com.example.platform.xstoragebucket import v1alpha1 as xstoragebucket
 from .model.io.upbound.aws.providerconfig import v1beta1 as providerconfig
+
+class Secret(BaseModel):
+    apiVersion: str = "v1"
+    kind: str = "Secret"
+    metadata: k8s.ObjectMeta
+    type: str = "Opaque"
+    data: dict[str, str] = {}
 
 bucket_manifest = xstoragebucket.XStorageBucket(
     metadata=k8s.ObjectMeta(
@@ -16,17 +27,31 @@ bucket_manifest = xstoragebucket.XStorageBucket(
     ),
 )
 
+provider_creds = Secret(
+    metadata=k8s.ObjectMeta(
+        name="aws-credentials",
+        namespace="crossplane-system",
+    ),
+    data={
+        "credentials": base64.b64encode(f'''[default]
+aws_access_key_id = {os.environ.get("UP_AWS_ACCESS_KEY_ID", "")}
+aws_secret_access_key = {os.environ.get("UP_AWS_SECRET_ACCESS_KEY", "")}
+aws_session_token = {os.environ.get("UP_AWS_SESSION_TOKEN", "")}
+'''.encode()).decode('ascii')
+    }
+)
+
 provider_config = providerconfig.ProviderConfig(
     metadata=k8s.ObjectMeta(
         name="default",
     ),
     spec=providerconfig.Spec(
         credentials=providerconfig.Credentials(
-            source="Upbound",
-            upbound=providerconfig.Upbound(
-                webIdentity=providerconfig.WebIdentity(
-                    roleARN="arn:aws:iam::609897127049:role/project-example-aws-uptest",
-                ),
+            source="Secret",
+            secretRef=providerconfig.SecretRef(
+                name="aws-credentials",
+                namespace="crossplane-system",
+                key="credentials",
             ),
         ),
     ),
@@ -46,7 +71,7 @@ test = e2etest.E2ETest(
             "Ready",
         ],
         manifests=[bucket_manifest.model_dump()],
-        extraResources=[provider_config.model_dump()],
+        extraResources=[provider_config.model_dump(), provider_creds.model_dump()],
         skipDelete=False,
         timeoutSeconds=900, # 15 minutes
     )

--- a/template/tests/e2etest-xstoragebucket-python/main.py
+++ b/template/tests/e2etest-xstoragebucket-python/main.py
@@ -25,7 +25,7 @@ provider_config = providerconfig.ProviderConfig(
             source="Upbound",
             upbound=providerconfig.Upbound(
                 webIdentity=providerconfig.WebIdentity(
-                    roleARN="arn:aws:iam::609897127049:role/example-project-aws-uptest",
+                    roleARN="arn:aws:iam::609897127049:role/project-example-aws-uptest",
                 ),
             ),
         ),


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

Rather than running each e2e test against a cloud development control plane, use the `--local` CLI argument to run it in a KIND cluster. Update the e2e test setup scripts to inject the AWS credentials into a secret and reference those, rather than using proidc. Also add `supportbundle` for easier debugging of e2e tests when things fail.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

https://github.com/upbound/project-example-aws/actions/runs/16156118183
