### PR TITLE
Add go-templating tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         language: [go, go-templating, kcl, python]
-        test-language: [kcl, python]
+        test-language: [go-templating, kcl, python]
     steps:
       - name: Checkout
         id: checkout
@@ -59,6 +59,9 @@ jobs:
 
       - name: Build project
         run: cd generated-project && up project build
+
+      - name: Run composition tests
+        run: cd generated-project && up test run tests/* --local --skip-control-plane-cleanup
 
       - name: Run e2e tests
         env:

--- a/template/tests/e2etest-xstoragebucket-go-templating/test.yaml.gotmpl
+++ b/template/tests/e2etest-xstoragebucket-go-templating/test.yaml.gotmpl
@@ -1,0 +1,57 @@
+# code: language=yaml
+# yaml-language-server: $schema=../../.up/json/models/test.schema.json
+
+{{ $aws_access_key_id := env "UP_AWS_ACCESS_KEY_ID" }}
+{{ $aws_secret_access_key := env "UP_AWS_SECRET_ACCESS_KEY" }}
+{{ $aws_session_token := env "UP_AWS_SESSION_TOKEN" }}
+{{ $aws_creds := (printf `[default]
+aws_access_key_id = %s
+aws_secret_access_key = %s
+aws_session_token = %s
+` $aws_access_key_id $aws_secret_access_key $aws_session_token) | b64enc }}
+
+items:
+- apiVersion: meta.dev.upbound.io/v1alpha1
+  kind: E2ETest
+  metadata:
+    name: e2etest-xstoragebucket
+  spec:
+    cleanupTimeoutSeconds: 600
+    crossplane:
+      autoUpgrade:
+        channel: Rapid
+      state: Running
+    defaultConditions:
+      - Ready
+    extraResources:
+      - apiVersion: aws.upbound.io/v1beta1
+        kind: ProviderConfig
+        metadata:
+          name: default
+        spec:
+          credentials:
+            secretRef:
+              key: credentials
+              name: aws-credentials
+              namespace: crossplane-system
+            source: Secret
+      - apiVersion: v1
+        kind: Secret
+        metadata:
+          name: aws-credentials
+          namespace: crossplane-system
+        type: Opaque
+        data:
+          credentials: {{ print $aws_creds }}
+    manifests:
+      - apiVersion: platform.example.com/v1alpha1
+        kind: XStorageBucket
+        metadata:
+          name: uptest-bucket-xr-kcl
+        spec:
+          parameters:
+            acl: private
+            region: eu-central-1
+            versioning: true
+    skipDelete: false
+    timeoutSeconds: 300

--- a/template/tests/test-xstoragebucket-go-templating/01-resources.yaml.gotmpl
+++ b/template/tests/test-xstoragebucket-go-templating/01-resources.yaml.gotmpl
@@ -1,0 +1,123 @@
+# code: language=yaml
+# yaml-language-server: $schema=../../.up/json/models/test.schema.json
+
+{{- $expectedXR := `
+- apiVersion: platform.example.com/v1alpha1
+  kind: XStorageBucket
+  metadata:
+    name: example
+  spec:
+    parameters:
+      acl: public-read
+      region: us-west-1
+      versioning: true
+`}}
+
+{{- $expectedBucketBefore := `
+- apiVersion: s3.aws.upbound.io/v1beta1
+  kind: Bucket
+  metadata:
+    annotations:
+      crossplane.io/composition-resource-name: bucket
+  spec:
+    forProvider:
+      region: us-west-1
+`}}
+
+{{- $observedBucket := `
+- apiVersion: s3.aws.upbound.io/v1beta1
+  kind: Bucket
+  metadata:
+    annotations:
+      crossplane.io/composition-resource-name: bucket
+      crossplane.io/external-name: example-bucket
+    name: example-bucket
+  spec:
+    forProvider:
+      region: us-west-1
+`}}
+
+{{- $expectedBucketAfter := `
+- apiVersion: s3.aws.upbound.io/v1beta1
+  kind: Bucket
+  metadata:
+    annotations:
+      crossplane.io/composition-resource-name: bucket
+    name: example-bucket
+  spec:
+    forProvider:
+      region: us-west-1
+`}}
+
+{{- $expectedACL := `
+- apiVersion: s3.aws.upbound.io/v1beta1
+  kind: BucketACL
+  metadata:
+    annotations:
+      crossplane.io/composition-resource-name: acl
+  spec:
+    forProvider:
+      acl: public-read
+      bucket: example-bucket
+      region: us-west-1
+`}}
+
+{{- $expectedBOC := `
+- apiVersion: s3.aws.upbound.io/v1beta1
+  kind: BucketOwnershipControls
+  metadata:
+    annotations:
+      crossplane.io/composition-resource-name: boc
+  spec:
+    forProvider:
+      bucket: example-bucket
+      region: us-west-1
+      rule:
+        - objectOwnership: BucketOwnerPreferred
+`}}
+
+{{- $expectedSSE := `
+- apiVersion: s3.aws.upbound.io/v1beta1
+  kind: BucketServerSideEncryptionConfiguration
+  metadata:
+    annotations:
+      crossplane.io/composition-resource-name: sse
+  spec:
+    forProvider:
+      bucket: example-bucket
+      region: us-west-1
+      rule:
+        - applyServerSideEncryptionByDefault:
+          - sseAlgorithm: AES256
+          bucketKeyEnabled: true
+`}}
+
+{{- $expectedPAB := `
+- apiVersion: s3.aws.upbound.io/v1beta1
+  kind: BucketPublicAccessBlock
+  metadata:
+    annotations:
+      crossplane.io/composition-resource-name: pab
+  spec:
+    forProvider:
+      blockPublicAcls: false
+      blockPublicPolicy: false
+      bucket: example-bucket
+      ignorePublicAcls: false
+      region: us-west-1
+      restrictPublicBuckets: false
+`}}
+
+{{- $expectedVersioning := `
+- apiVersion: s3.aws.upbound.io/v1beta1
+  kind: BucketVersioning
+  metadata:
+    annotations:
+      crossplane.io/composition-resource-name: versioning
+  spec:
+    forProvider:
+      bucket: example-bucket
+      region: us-west-1
+      versioningConfiguration:
+        - status: Enabled
+`}}

--- a/template/tests/test-xstoragebucket-go-templating/02-test.yaml.gotmpl
+++ b/template/tests/test-xstoragebucket-go-templating/02-test.yaml.gotmpl
@@ -1,0 +1,53 @@
+# code: language=yaml
+# yaml-language-server: $schema=../../.up/json/models/test.schema.json
+
+# This test suite validates the creation of resources for the XStorageBucket XR.
+#
+# Creation of resources happens in two sequential calls to the composition
+# function:
+#
+# 1. The first time the function is called, the bucket has not yet been
+#    created. Other resources depend on the bucket's name, so the function
+#    creates only the bucket.
+#
+# 2. When the function is called again after the bucket has been created, its
+#    name is available, so the rest of the resources can be created.
+#
+# The test suite contains two tests, one for each of the sequential calls. The
+# second test includes the bucket in its observed resources, triggering creation
+# of the dependent resources.
+
+items:
+- apiVersion: meta.dev.upbound.io/v1alpha1
+  kind: CompositionTest
+  metadata:
+    name: "test-xstoragebucket-bucket-not-yet-created"
+  spec:
+    assertResources:
+      {{- print $expectedXR | indent 6 }}
+      {{- print $expectedBucketBefore | indent 6 }}
+    compositionPath: "apis/xstoragebucket/composition.yaml"
+    xrPath: "examples/xstoragebuckets/example.yaml"
+    xrdPath: "apis/xstoragebucket/definition.yaml"
+    timeoutSeconds: 120
+    validate: false
+- apiVersion: meta.dev.upbound.io/v1alpha1
+  kind: CompositionTest
+  metadata:
+    name: "test-xstoragebucket-bucket-created"
+  spec:
+    observedResources:
+      {{- print $observedBucket | indent 6 }}
+    assertResources:
+      {{- print $expectedXR | indent 6 }}
+      {{- print $expectedBucketAfter | indent 6 }}
+      {{- print $expectedACL | nindent 6 }}
+      {{- print $expectedBOC | nindent 6 }}
+      {{- print $expectedPAB | nindent 6}}
+      {{- print $expectedSSE | nindent 6}}
+      {{- print $expectedVersioning | nindent 6}}
+    compositionPath: "apis/xstoragebucket/composition.yaml"
+    xrPath: "examples/xstoragebuckets/example.yaml"
+    xrdPath: "apis/xstoragebucket/definition.yaml"
+    timeoutSeconds: 120
+    validate: false


### PR DESCRIPTION
### Description of your changes

Add a go-templating implementation of the tests, matching the other implementations. Add go-templating to the test matrix in CI, and also add a step to run composition tests, since we weren't exercising them previously.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
~- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.~

### How has this code been tested

Composition tests tested locally; will rely on CI for the e2e tests.
