### PR TITLE
fix: Bump Project API from meta.dev.upbound.io/v1alpha1 to v2alpha1

### DIFF
--- a/template/upbound.yaml
+++ b/template/upbound.yaml
@@ -1,4 +1,4 @@
-apiVersion: meta.dev.upbound.io/v1alpha1
+apiVersion: meta.dev.upbound.io/v2alpha1
 kind: Project
 metadata:
   name: project-template-aws-s3


### PR DESCRIPTION
## Summary
- Bump Project API from `meta.dev.upbound.io/v1alpha1` to `v2alpha1`

## Test plan
- [x] `up project build` succeeds against the template
- [x] Install resulting configuration on a Crossplane v1.20+ control plane
- [x] Install resulting configuration on a Crossplane v2 control plane